### PR TITLE
pc - add link to admin page on home page only when user is an admin

### DIFF
--- a/apis/users/index.js
+++ b/apis/users/index.js
@@ -18,6 +18,20 @@ function update_self(firstName, lastName) {
 	return true;
 }
 
+async function get_user_info(uid) {
+	let result = await db.sequelize.query(
+		'SELECT * ' +
+		`FROM Users AS u `+
+		'WHERE u.id = ?' ,
+		{
+			type: QueryTypes.SELECT,
+			replacements: [uid]
+		}).then((dbRes) => {
+			return dbRes[0];
+		});
+		return result;
+}
+
 async function get_user_wealth(cid, uid) {
 	let result = await db.sequelize.query(
 		'SELECT SUM(uw.wealth) ' +
@@ -466,6 +480,6 @@ module.exports = {
 	get_common_day,
 	get_end_date,
 	get_all_milkings,
-	get_user_total
+	get_user_total,
+	get_user_info
 }
-

--- a/templates/user_select_commons.ejs
+++ b/templates/user_select_commons.ejs
@@ -33,6 +33,22 @@
                             </div>
                         </div>
                     </div>
+                    <% if (data && data.user_info && data.user_info.type && data.user_info.type==='admin') { %>
+                        <div class="row">
+                            <div class="col-xl-12 col-lg-12 col-md-12 col-sm-12 col-12">
+                                <div class="card special-card">
+                                    <div class="page-caption">
+                                        <!-- <h1 class="ml9"> -->
+                                            <span class="text-wrapper">
+                                                <span class="letters"><a href="/admin">admin page</a></span>
+                                            </span>
+                                        <!-- </h1> -->
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    <% } %>
+                    
                     <div class = "row mt-5">
                         <div class="col-xl-6 col-lg-6 col-md-12 col-sm-12 col-6">
                             <div class="card special-card">

--- a/views/user_choose_commons.js
+++ b/views/user_choose_commons.js
@@ -1,14 +1,17 @@
-const {get_all_commons, get_user_commons} = require("../apis/users/index");
+const {get_all_commons, get_user_commons, get_user_info} = require("../apis/users/index");
 
 module.exports = async (req, res)=>{
     const user_obj = res.locals.user;  //is user_obj all strings? or will I have to convert user_obj.id to string
     const commons = await get_all_commons(req);
     const commons_user = await get_user_commons(req, String(user_obj.id));
+    const user_info = await get_user_info(String(user_obj.id));
+    console.log("user_info=",user_info);
     res.render('user_select_commons',
     {data: 
         {
             commons: commons,
-            commons_user: commons_user
+            commons_user: commons_user,
+            user_info: user_info
         }
     }
 )};


### PR DESCRIPTION
In this PR, we add a link on the home page that is only active when the user is an admin.

Regular users are not affected.

But admins now see this on their home screen:

<img width="1193" alt="image" src="https://user-images.githubusercontent.com/1119017/115083549-61fddf00-9ebc-11eb-9790-ae72754238e5.png">

Note that there are already protections in place to prevent non-admins from accessing the admin page, so this doesn't introduce any new security risks as far as we know.

This is not necessarily an important new feature; but it does give our dev team practice with modifying the current code base; practice we may need in order to solve the current scaling issues.